### PR TITLE
fix-search-tool-and-dev-testing

### DIFF
--- a/mcp_client.py
+++ b/mcp_client.py
@@ -7,6 +7,7 @@ A command-line client for interacting with the Nuxeo MCP Server using the FastMC
 
 import argparse
 import asyncio
+from collections.abc import Iterable
 import json
 import sys
 from typing import Dict, Any, Optional
@@ -115,12 +116,13 @@ async def get_document(url: str, path: Optional[str] = None, uid: Optional[str] 
             print("Connected successfully, calling get_document tool...")
             result = await client.call_tool("get_document", arguments)
 
-            for content in result:
-                if type(content) == TextContent:
-                    return content.text
-                else:
-                    print(f"#### Unhandled Content Type {type(content)} ")
-    
+            if isinstance(result, Iterable):
+                for content in result:
+                    if type(content) == TextContent:
+                        return content.text
+                    else:
+                        print(f"#### Unhandled Content Type {type(content)} ")
+
             return result
         
 


### PR DESCRIPTION
This is just a stop-gap ( the fix is relevant, but just surface level).
There are two underlying issues:
1. The mcp client is only tested in the CI, leading to failures we don't see without manual testing or CI runs. it would be useful to make a test_suit that does the calls written in the CI, so we can call it in the CI and on dev workstations easily
2. I didn't look into it, but it would be worth it having a mental model of why calling how gives which response format and how we want to treat it.

Note: the offending output is correct, but newlines are escaped and everything is slugged in a `CallToolResult`